### PR TITLE
ci: try fixing CLA bot

### DIFF
--- a/.github/workflows/cla_assistant.yml
+++ b/.github/workflows/cla_assistant.yml
@@ -16,6 +16,7 @@ jobs:
         uses: contributor-assistant/github-action@v2.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PERSONAL_ACCESS_TOKEN : ${{ secrets.CLA_BOT_ACCESS_TOKEN }}
         with:
           remote-organization-name: qir-alliance
           remote-repository-name: data_storage

--- a/.github/workflows/cla_assistant.yml
+++ b/.github/workflows/cla_assistant.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: "CLA Assistant"
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the Contributor License Agreement and I hereby accept the Terms.') || github.event_name == 'pull_request_target'
-        uses: contributor-assistant/github-action@v2.6.1
+        uses: contributor-assistant/github-action@v2.3.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PERSONAL_ACCESS_TOKEN : ${{ secrets.CLA_BOT_ACCESS_TOKEN }}


### PR DESCRIPTION
It seems what's happening is that when I made the update in https://github.com/qir-alliance/qir-spec/pull/42 it was still using the version of CLA bot on `main`. Once that got merged, it switched to the version I introduced without the PAT.

This is confirmed here in this PR because I am downgrading to v2.3.2, but the GH action is still running v2.6.1 of the CLA action. Perhaps merging this PR to `main` will fix it. But I am not 100% sure.

Sorry for the troubles. I will let others who have admin access to the repo look more.