### PR TITLE
feat: Spec for dynamic allocation & arrays

### DIFF
--- a/specification/Instruction_Set.md
+++ b/specification/Instruction_Set.md
@@ -32,6 +32,14 @@ of qubits and measurements of qubits. Additional functions may be needed to
 support the use of data types beyond those for qubit and measurement result
 values.
 
+## Dynamic Allocation and Arrays
+
+In addition to static allocation of qubits and results, QIR 2.0 supports dynamic
+allocation of these resources and their arrays. This allows for more flexible
+programs where the number of qubits or results is not known at compile time.
+For more details on the specific runtime functions and usage, please see the
+[Dynamic Allocation and Arrays](Memory_Management.md) specification.
+
 ## Quantum Instruction Set (QIS)
 
 The table below lists known quantum instructions along with their signatures and

--- a/specification/Instruction_Set.md
+++ b/specification/Instruction_Set.md
@@ -34,7 +34,7 @@ values.
 
 ## Dynamic Allocation and Arrays
 
-In addition to static allocation of qubits and results, QIR 2.0 supports dynamic
+In addition to static allocation of qubits and results, QIR supports dynamic
 allocation of these resources and their arrays. This allows for more flexible
 programs where the number of qubits or results is not known at compile time.
 For more details on the specific runtime functions and usage, please see the

--- a/specification/Memory_Management.md
+++ b/specification/Memory_Management.md
@@ -36,8 +36,6 @@ stack allocation and native LLVM arrays).
 
 ## Array Support
 
-### Overview
-
 Array support provides first-class native LLVM array types for all supported
 types in QIR. While this specification focuses on arrays of qubits and results
 (the primary use case), the array capability is general and applies to any type
@@ -110,6 +108,8 @@ store ptr inttoptr (i64 1 to ptr), ptr %q1_ptr, align 8
 ; Use the qubits
 %q0 = load ptr, ptr %q0_ptr, align 8
 call void @__quantum__qis__h__body(ptr %q0)
+%q1 = load ptr, ptr %q1_ptr, align 8
+call void @__quantum__qis__h__body(ptr %q1)
 ```
 
 **Static array with dynamically-allocated results:**
@@ -138,8 +138,6 @@ call void @__quantum__rt__result_release(ptr %r0)
 
 ## Dynamic Allocation
 
-### Overview
-
 Dynamic allocation enables runtime allocation and release of qubits and results,
 allowing programs to determine resource requirements during execution rather
 than at compile time.
@@ -161,9 +159,9 @@ and deallocation.
 
 ```llvm
 ; Returns a pointer value for a single qubit, initially in the ground state.
-; If `%out_err` is null, allocation failure results in runtime termination.
-; If `%out_err` is non-null, it must point to valid memory for an `i1` value.
-; On allocation failure, the `i1` is set to true and null is returned.
+; If `%out_err` is `null`, allocation failure results in runtime termination.
+; If `%out_err` is non-`null`, it must point to valid memory for an `i1` value.
+; On allocation failure, the `i1` is set to true and `null` is returned.
 ; On success, the `i1` is set to false and a valid qubit pointer is returned.
 declare ptr @__quantum__rt__qubit_allocate(ptr %out_err)
 
@@ -179,9 +177,9 @@ declare void @__quantum__rt__qubit_release(ptr %qubit)
 ; Returns a pointer value for a single measurement result, initially in a state
 ; such that calls to `__quantum__rt__read_result` with that pointer will return
 ; false.
-; If `%out_err` is null, allocation failure results in runtime termination.
-; If `%out_err` is non-null, it must point to valid memory for an `i1` value.
-; On allocation failure, the `i1` is set to true and null is returned.
+; If `%out_err` is `null`, allocation failure results in runtime termination.
+; If `%out_err` is non-`null`, it must point to valid memory for an `i1` value.
+; On allocation failure, the `i1` is set to true and `null` is returned.
 ; On success, the `i1` is set to false and a valid result pointer is returned.
 declare ptr @__quantum__rt__result_allocate(ptr %out_err)
 
@@ -204,8 +202,8 @@ These functions require the caller to provide a pre-allocated array buffer.
 ; state, storing the resulting pointer values into memory at the given pointer.
 ; The caller is responsible for ensuring `%array` points to valid memory with
 ; enough space to support writing `%N * sizeof(ptr)` values.
-; If `%out_err` is null, allocation failure results in runtime termination.
-; If `%out_err` is non-null, it must point to valid memory for an `i1` value.
+; If `%out_err` is `null`, allocation failure results in runtime termination.
+; If `%out_err` is non-`null`, it must point to valid memory for an `i1` value.
 ; On allocation failure, the `i1` is set to true. On success, the `i1` is set to
 ; false.
 declare void @__quantum__rt__qubit_array_allocate(i64 %N, ptr %array, ptr %out_err)
@@ -228,8 +226,8 @@ declare void @__quantum__rt__qubit_array_release(i64 %N, ptr %array)
 ; ensuring `%array` points to valid memory with enough space to support writing
 ; `%N * sizeof(ptr)` values. All returned results are initially in a state such
 ; that calls to `__quantum__rt__read_result` with that pointer will return false.
-; If `%out_err` is null, allocation failure results in runtime termination.
-; If `%out_err` is non-null, it must point to valid memory for an `i1` value.
+; If `%out_err` is `null`, allocation failure results in runtime termination.
+; If `%out_err` is non-`null`, it must point to valid memory for an `i1` value.
 ; On allocation failure, the `i1` is set to true. On success, the `i1` is set to
 ; false.
 declare void @__quantum__rt__result_array_allocate(i64 %N, ptr %array, ptr %out_err)
@@ -322,10 +320,10 @@ call void @__quantum__rt__result_array_release(i64 3, ptr %results)
 When both arrays and dynamic allocation are available, programs have flexibility
 in how they manage quantum resources:
 
-| **Array Storage**              | **Static Object IDs**          | **Dynamic Object Allocation** |
-|--------------------------------|--------------------------------|-------------------------------|
-| **Stack (compile-time size)**  | Fixed-size array; compile-time IDs | Fixed-size array; runtime allocation |
-| **Heap (runtime size)**        | Runtime-sized buffer; compile-time IDs | Runtime-sized buffer; runtime allocation |
+| **Array Storage**             | **Static Object IDs**                  | **Dynamic Object Allocation**            |
+|-------------------------------|----------------------------------------|------------------------------------------|
+| **Stack (compile-time size)** | Fixed-size array; compile-time IDs     | Fixed-size array; runtime allocation     |
+| **Heap (runtime size)**       | Runtime-sized buffer; compile-time IDs | Runtime-sized buffer; runtime allocation |
 
 This matrix clarifies the independence of the two capabilities while showing how
 they combine to support various programming patterns.
@@ -366,7 +364,7 @@ for error handling:
 
 - If `%out_err` is `null`, allocation failure results in runtime termination
   (crash). This is the common case for most programs.
-- If `%out_err` is non-null, the caller must have allocated memory for an `i1`
+- If `%out_err` is non-`null`, the caller must have allocated memory for an `i1`
   and passed a pointer to it. The runtime will set this `i1` to `true` on
   allocation failure and `false` on success. Advanced users can check this flag
   to handle allocation failures gracefully.

--- a/specification/Memory_Management.md
+++ b/specification/Memory_Management.md
@@ -1,137 +1,372 @@
 
-# Dynamic Allocation and Arrays
+# Arrays and Dynamic Allocation
 
 As of v1.0, QIR only supported handling of qubits and results statically known
-at compile time. This extension for QIR 2.0
-[Adaptive Profile](./profiles/Adaptive_Profile.md) adds the ability to
-dynamically allocate qubits, results and their arrays.
+at compile time, and did not provide native array support. This extension for
+QIR 2.0 [Adaptive Profile](./profiles/Adaptive_Profile.md) adds two independent
+capabilities:
+
+1. **Arrays**: First-class support for arrays of any supported type using native
+   LLVM array types
+2. **Dynamic allocation**: Runtime allocation of qubits and results
+
+These capabilities are orthogonal and can be used independently or together.
 
 ## Motivation & Scope
 
-Dynamic qubit/result allocation and first-class array support enable QIR to represent
-algorithms and workflows that require:
+**Array support** enables QIR to represent algorithms and workflows that require:
 
-- Allocating ancilla qubits or measurement results at runtime (e.g., for quantum
-  error correction, variational algorithms, or parameterized circuits)
-- Passing qubits and arrays as function arguments, supporting modular and
-  scalable quantum programs
-- Iterating over arrays of qubits/results and returning arrays of measurement results
-- Efficient targeting of devices with varying qubit counts and improved
-  interoperability with advanced quantum languages
+- Passing collections of qubits or results as function arguments
+- Iterating over collections of quantum resources
+- Returning arrays of measurement results
+- Working with any supported type in aggregate form
+- Modular and scalable quantum program structure
 
-This extension maintains backward compatibility with existing QIR tooling and
-profiles, and is designed to keep classical memory management simple (favoring
+**Dynamic allocation** enables QIR to represent algorithms and workflows that
+require:
+
+- Allocating qubits or results at runtime (e.g., for quantum error correction,
+  variational algorithms, or parameterized circuits)
+- Efficient targeting of devices with varying qubit counts
+- Adaptively determining resource requirements during execution
+
+These extensions maintain backward compatibility with existing QIR tooling and
+profiles, and are designed to keep classical memory management simple (favoring
 stack allocation and native LLVM arrays).
 
-## Specification
+## Array Support
+
+### Overview
+
+Array support provides first-class native LLVM array types for all supported
+types in QIR. While this specification focuses on arrays of qubits and results
+(the primary use case), the array capability is general and applies to any type
+that a profile supports.
+
+### Enabling Arrays
+
+To use arrays, set the following module flag to `true`:
+
+- `"arrays"`
+
+When enabled, programs may use native LLVM array types (e.g., `[N x ptr]` for
+arrays of qubits or results) and associated LLVM array operations regardless of
+whether the contained objects are allocated statically or dynamically.
+
+### Supported LLVM Array Operations
+
+When arrays are enabled, the following LLVM features must be supported:
+
+- **Array types**: Native LLVM array types such as `[N x ptr]`
+- **Stack allocation**: The `alloca` instruction for stack-allocated arrays with
+  compile-time known sizes
+- **Element access**: The `getelementptr` (GEP) instruction for computing
+  addresses of array elements
+- **Aggregate operations**: The `extractvalue` and `insertvalue` instructions
+  for accessing and modifying elements
+- **Load/Store**: Standard `load` and `store` instructions for reading from and
+  writing to array elements
+
+Note that LLVM does not natively support dynamically-sized arrays (arrays whose
+size is determined at runtime). For runtime-sized collections, classical memory
+management remains the responsibility of the caller.
+
+### Array Output Recording for Results
+
+When arrays are enabled, the following specialized function is available to
+record an entire measurement result array in a single output record:
+
+```llvm
+declare void @__quantum__rt__result_array_record_output(i64 %N, ptr %result_array, ptr %tag)
+```
+
+`%N` is the size of `%result_array`. `%result_array` must point to valid memory
+containing `%N` sequential result pointers. The array is rendered in the output
+in memory order: the first element in the array (at the lowest memory address,
+`%result_array[0]`) appears first (leftmost) in the output, followed by
+subsequent elements in order.
+
+**Note:** This is the only specialized array output recording function. No
+additional output recording functions will be introduced for other types or
+purposes. See the [output schemas](./output_schemas/) documentation for specific
+rendering details.
+
+### Array Examples
+
+**Static array of statically-allocated qubits:**
+
+```llvm
+; Declare an array of 5 qubit pointers
+%qubits = alloca [5 x ptr], align 8
+
+; Initialize with statically-allocated qubits (using integer-to-pointer casts)
+%q0_ptr = getelementptr inbounds [5 x ptr], ptr %qubits, i64 0, i64 0
+store ptr inttoptr (i64 0 to ptr), ptr %q0_ptr, align 8
+
+%q1_ptr = getelementptr inbounds [5 x ptr], ptr %qubits, i64 0, i64 1
+store ptr inttoptr (i64 1 to ptr), ptr %q1_ptr, align 8
+; ... etc
+
+; Use the qubits
+%q0 = load ptr, ptr %q0_ptr, align 8
+call void @__quantum__qis__h__body(ptr %q0)
+```
+
+**Static array with dynamically-allocated results:**
+
+```llvm
+; Requires both arrays=true and dynamic_result_management=true
+%results = alloca [3 x ptr], align 8
+
+; Allocate each result individually
+%r0 = call ptr @__quantum__rt__result_allocate(ptr null)
+%r0_ptr = getelementptr inbounds [3 x ptr], ptr %results, i64 0, i64 0
+store ptr %r0, ptr %r0_ptr, align 8
+; ... allocate and store r1, r2
+
+; Perform measurements
+%r0_loaded = load ptr, ptr %r0_ptr, align 8
+call void @__quantum__qis__mz__body(ptr %qubit0, ptr %r0_loaded)
+
+; Record the entire array
+call void @__quantum__rt__result_array_record_output(i64 3, ptr %results, ptr @tag)
+
+; Release each result
+call void @__quantum__rt__result_release(ptr %r0)
+; ... release r1, r2
+```
+
+## Dynamic Allocation
+
+### Overview
+
+Dynamic allocation enables runtime allocation and release of qubits and results,
+allowing programs to determine resource requirements during execution rather
+than at compile time.
 
 ### Enabling Dynamic Memory Management
 
 To use dynamic allocation, set the following module flags to `true`:
 
-- `"dynamic_qubit_management"`
-- `"dynamic_result_management"`
+- `"dynamic_qubit_management"` - enables dynamic allocation of qubits
+- `"dynamic_result_management"` - enables dynamic allocation of results
 
-When these flags are set, the `required_num_qubits` and `required_num_results`
-attributes on the entry point are not required; the runtime manages allocation.
+When these flags are set, the `required_num_qubits` and/or `required_num_results`
+attributes on the entry point are not required; the runtime manages allocation
+and deallocation.
 
-### Enabling Array Support
+### Single-Resource Allocation API
 
-To use arrays of qubits and results, set the following module flag to `true`:
-
-- `"arrays"`
-
-This flag enables array support for both qubits and results, regardless of
-whether they are allocated statically or dynamically.
-
-### Types
-
-Use native LLVM array types (`[%N x ptr]`) and `alloca` for stack
-allocation, or heap allocation as needed.
-
-### Runtime API
-
-**Qubit management:**
+**Qubit allocation:**
 
 ```llvm
+; Returns a pointer value for a single qubit, initially in the ground state.
+; If `%out_err` is null, allocation failure results in runtime termination.
+; If `%out_err` is non-null, it must point to valid memory for an `i1` value.
+; On allocation failure, the `i1` is set to true and null is returned.
+; On success, the `i1` is set to false and a valid qubit pointer is returned.
 declare ptr @__quantum__rt__qubit_allocate(ptr %out_err)
+
+; Release a single qubit, such that the pointer value is no longer valid after
+; this function returns and the referenced qubit is available for allocation by
+; later runtime calls in the program.
 declare void @__quantum__rt__qubit_release(ptr %qubit)
-; Caller provides a buffer capable of holding N pointer-sized entries.
+```
+
+**Result allocation:**
+
+```llvm
+; Returns a pointer value for a single measurement result, initially in a state
+; such that calls to `__quantum__rt__read_result` with that pointer will return
+; false.
+; If `%out_err` is null, allocation failure results in runtime termination.
+; If `%out_err` is non-null, it must point to valid memory for an `i1` value.
+; On allocation failure, the `i1` is set to true and null is returned.
+; On success, the `i1` is set to false and a valid result pointer is returned.
+declare ptr @__quantum__rt__result_allocate(ptr %out_err)
+
+; Release a single result, such that the pointer value is no longer valid after
+; this function returns and the referenced measurement result is available for
+; allocation by later runtime calls in the program.
+declare void @__quantum__rt__result_release(ptr %result)
+```
+
+### Bulk Allocation API (Requires Arrays)
+
+When both dynamic allocation **and** array support are enabled, bulk allocation
+functions are available that efficiently allocate multiple resources at once.
+These functions require the caller to provide a pre-allocated array buffer.
+
+**Qubit array allocation:**
+
+```llvm
+; Performs an allocation of the given number of qubits, initially in the ground
+; state, storing the resulting pointer values into memory at the given pointer.
+; The caller is responsible for ensuring `%array` points to valid memory with
+; enough space to support writing `%N * sizeof(ptr)` values.
+; If `%out_err` is null, allocation failure results in runtime termination.
+; If `%out_err` is non-null, it must point to valid memory for an `i1` value.
+; On allocation failure, the `i1` is set to true. On success, the `i1` is set to
+; false.
 declare void @__quantum__rt__qubit_array_allocate(i64 %N, ptr %array, ptr %out_err)
+
+; Releases the given qubits read from the given memory. `%array` must point to
+; valid memory that contains `%N` sequential pointer values. All pointers stored
+; in that memory must correspond to currently allocated qubits. These pointer
+; values are no longer valid after this function returns and the referenced
+; qubits are available for allocation by later runtime calls in the program. The
+; memory pointed to by `%array` is left unchanged and management of that memory
+; is the responsibility of caller.
 declare void @__quantum__rt__qubit_array_release(i64 %N, ptr %array)
 ```
 
-**Result management:**
+**Result array allocation:**
 
 ```llvm
-declare ptr @__quantum__rt__result_allocate(ptr %out_err)
-declare void @__quantum__rt__result_release(ptr %result)
+; Performs an allocation of the given number of results, storing the resulting
+; pointer values into memory at the given pointer. The caller is responsible for
+; ensuring `%array` points to valid memory with enough space to support writing
+; `%N * sizeof(ptr)` values. All returned results are initially in a state such
+; that calls to `__quantum__rt__read_result` with that pointer will return false.
+; If `%out_err` is null, allocation failure results in runtime termination.
+; If `%out_err` is non-null, it must point to valid memory for an `i1` value.
+; On allocation failure, the `i1` is set to true. On success, the `i1` is set to
+; false.
 declare void @__quantum__rt__result_array_allocate(i64 %N, ptr %array, ptr %out_err)
+
+; Releases the given results read from the given memory. `%array` must point to
+; valid memory that contains `%N` sequential pointer values. All pointers stored
+; in that memory must correspond to currently allocated results. These pointer
+; values are no longer valid after this function returns and the referenced
+; measurement results are available for allocation by later runtime calls in the
+; program. The memory pointed to by `%array` is left unchanged and management of
+; that memory is the responsibility of caller.
 declare void @__quantum__rt__result_array_release(i64 %N, ptr %array)
 ```
 
-**Notes:**
+**Separation of classical and quantum memory management:**
 
-- The `array_allocate` functions write N pointer values into the memory at
-  `%array`. The caller is responsible for allocating and freeing the classical
-  memory.
-- The `array_release` functions release the runtime-managed objects, but do not
-  free the classical buffer.
+The bulk allocation functions explicitly separate the responsibilities of
+classical and quantum memory management:
 
-**Error handling:**
+- **Classical memory (the array buffer)**: Managed entirely by the caller using
+  standard LLVM memory operations. The caller allocates memory (typically via
+  `alloca` for stack allocation), passes a pointer to this memory to the
+  allocation function, and is responsible for the lifetime of this memory.
+- **Quantum objects (qubits/results)**: Managed by the runtime. The runtime
+  allocates the quantum resources and writes pointers to them into the
+  caller-provided buffer. The runtime tracks which quantum resources are
+  allocated and releases them when `*_release` is called.
 
-- All allocation functions accept an optional output parameter `%out_err` for
-  error handling.
+This separation keeps memory semantics simple, leverages LLVM's native array and
+aggregate operations, and avoids requiring backends to manage classical memory
+for arrays.
+
+### Dynamic Allocation Examples
+
+**Single qubit allocation:**
+
+```llvm
+%qubit = call ptr @__quantum__rt__qubit_allocate(ptr null)
+call void @__quantum__qis__h__body(ptr %qubit)
+call void @__quantum__rt__qubit_release(ptr %qubit)
+```
+
+**Single qubit allocation with error checking:**
+
+```llvm
+%err = alloca i1, align 1
+%qubit = call ptr @__quantum__rt__qubit_allocate(ptr %err)
+%failed = load i1, ptr %err, align 1
+br i1 %failed, label %error_handler, label %continue
+error_handler:
+  ; Handle allocation failure
+  ret void
+continue:
+  ; Use the qubit
+  call void @__quantum__qis__h__body(ptr %qubit)
+  call void @__quantum__rt__qubit_release(ptr %qubit)
+  ret void
+```
+
+**Bulk qubit allocation (requires arrays):**
+
+```llvm
+%qubits = alloca [5 x ptr], align 8
+call void @__quantum__rt__qubit_array_allocate(i64 5, ptr %qubits, ptr null)
+; Use the qubits...
+%q0_ptr = getelementptr inbounds [5 x ptr], ptr %qubits, i64 0, i64 0
+%q0 = load ptr, ptr %q0_ptr, align 8
+call void @__quantum__qis__h__body(ptr %q0)
+; Release when done
+call void @__quantum__rt__qubit_array_release(i64 5, ptr %qubits)
+```
+
+**Result array allocation and output (requires arrays):**
+
+```llvm
+%results = alloca [3 x ptr], align 8
+call void @__quantum__rt__result_array_allocate(i64 3, ptr %results, ptr null)
+; Perform measurements into the result array...
+%r0_ptr = getelementptr inbounds [3 x ptr], ptr %results, i64 0, i64 0
+%r0 = load ptr, ptr %r0_ptr, align 8
+call void @__quantum__qis__mz__body(ptr %qubit0, ptr %r0)
+; Record the entire array as output
+call void @__quantum__rt__result_array_record_output(i64 3, ptr %results, ptr @tag)
+; Release when done
+call void @__quantum__rt__result_array_release(i64 3, ptr %results)
+```
+
+## Combined Capabilities Matrix
+
+When both arrays and dynamic allocation are available, programs have flexibility
+in how they manage quantum resources:
+
+| **Array Storage**              | **Static Object IDs**          | **Dynamic Object Allocation** |
+|--------------------------------|--------------------------------|-------------------------------|
+| **Stack (compile-time size)**  | Fixed-size array; compile-time IDs | Fixed-size array; runtime allocation |
+| **Heap (runtime size)**        | Runtime-sized buffer; compile-time IDs | Runtime-sized buffer; runtime allocation |
+
+This matrix clarifies the independence of the two capabilities while showing how
+they combine to support various programming patterns.
+
+## General Considerations
+
+### Resource State After Release
+
+**Qubits:** The state of a qubit after `__quantum__rt__qubit_release` is
+backend-specific. Backends may return qubits in a clean state (e.g., reset to
+|0⟩) or in a dirty state (whatever state the qubit was in when released).
+Programs should not rely on any particular state and should explicitly reset
+qubits if a known state is required before reallocation.
+
+**Results:** Results are returned to the runtime and are available for
+reallocation. The state is implementation-defined.
+
+### Use-After-Free/Release Behavior
+
+Using a qubit or result pointer after it has been released via `*_release`
+results in **undefined behavior**. This includes:
+
+- Applying quantum operations to a released qubit pointer
+- Reading or recording a released result pointer
+- Passing a released pointer to any runtime or QIS function
+- Including a released pointer in a subsequent `*_array_release` call
+
+Backends are not required to detect use-after-free errors, and the behavior in
+such cases is implementation-defined. Backends may crash, silently ignore the
+operation, or produce incorrect results. It is the responsibility of the QIR
+generator (compiler/frontend) to ensure that pointers are not used after being
+released.
+
+### Error Handling
+
+All dynamic allocation functions accept an optional output parameter `%out_err`
+for error handling:
+
 - If `%out_err` is `null`, allocation failure results in runtime termination
   (crash). This is the common case for most programs.
 - If `%out_err` is non-null, the caller must have allocated memory for an `i1`
   and passed a pointer to it. The runtime will set this `i1` to `true` on
   allocation failure and `false` on success. Advanced users can check this flag
   to handle allocation failures gracefully.
-
-### Array Output Recording
-
-To record/print an entire measurement result array in one line:
-
-```llvm
-declare void @__quantum__rt__result_array_record_output(i64 %N, ptr %result_array, ptr %tag)
-```
-
-`%N` is the size of `%result_array`. Endianness for rendering is undecided.
-
-**Note:** This is the only specialized array output recording function. No
-additional output recording functions will be introduced for other types or
-purposes.
-
-### Support Matrix
-
-When describing container/object capabilities, consider two axes:
-
-- Container allocation: Stack (compile-time size) vs Heap (runtime size)
-- Object creation: Dynamic (via `dynamic_*_management` flags) vs Static
-  (compile-time ID via `required_num_*` flags)
-
-This yields four supported scenarios (stack/heap × dynamic/static) and clarifies
-compiler/runtime responsibilities.
-
-### Qubit State After Release
-
-The state of a qubit after `__quantum__rt__qubit_release` is backend-specific.
-Backends may return qubits in a clean state (e.g., reset to |0⟩) or in a dirty
-state (whatever state the qubit was in when released). Programs should not rely
-on any particular state and should explicitly reset qubits if a known state is
-required.
-
-### Rationale and Implementation Notes
-
-- Caller-managed classical memory keeps memory semantics simple and leverages
-  LLVM's native array and aggregate operations.
-- Separating classical memory lifetime from runtime-managed quantum objects
-  simplifies backends.
-- The error handling approach via output parameters allows most programs to use
-  simple allocation with implicit failure handling while enabling advanced users
-  to handle allocation failures explicitly.
-
-## Open Questions
-
-- Exact semantics for `result_array_record_output` formatting (endianness)

--- a/specification/Memory_Management.md
+++ b/specification/Memory_Management.md
@@ -374,11 +374,12 @@ they combine to support various programming patterns.
 
 ### Resource State After Release
 
-**Qubits:** The state of a qubit after `__quantum__rt__qubit_release` is
-backend-specific. Backends may return qubits in a clean state (e.g., reset to
-|0⟩) or in a dirty state (whatever state the qubit was in when released).
-Programs should not rely on any particular state and should explicitly reset
-qubits if a known state is required before reallocation.
+**Qubits:** After `__quantum__rt__qubit_release`, the pointer is invalid and the
+program can no longer observe the state of the released qubit. The runtime may
+perform any cleanup it requires before making that qubit available for a later
+allocation. On every successful call to `__quantum__rt__qubit_allocate` or
+`__quantum__rt__qubit_array_allocate`, the backend must return qubits in the
+ground state.
 
 **Results:** Results are returned to the runtime and are available for
 reallocation. The state is implementation-defined.

--- a/specification/Memory_Management.md
+++ b/specification/Memory_Management.md
@@ -272,6 +272,13 @@ call void @__quantum__rt__qubit_release(ptr %qubit)
 
 **Single qubit allocation with error checking:**
 
+This example shows how to handle allocation failures gracefully. By passing a
+non-null pointer to an `i1` as the `%out_err` parameter, the caller can check
+whether allocation succeeded. If allocation fails, the runtime sets the `i1` to
+`true` and returns `null`; otherwise it sets the `i1` to `false` and returns a
+valid qubit pointer. If `%out_err` is `null`, allocation failure terminates the
+program.
+
 ```llvm
 %err = alloca i1, align 1
 %qubit = call ptr @__quantum__rt__qubit_allocate(ptr %err)

--- a/specification/Memory_Management.md
+++ b/specification/Memory_Management.md
@@ -1,10 +1,9 @@
 
 # Arrays and Dynamic Allocation
 
-As of v1.0, QIR only supported handling of qubits and results statically known
-at compile time, and did not provide native array support. This extension for
-QIR 2.0 [Adaptive Profile](./profiles/Adaptive_Profile.md) adds two independent
-capabilities:
+This specification defines optional arrays and dynamic allocation capabilities
+for the [Adaptive Profile](./profiles/Adaptive_Profile.md). It adds two
+independent capabilities:
 
 1. **Arrays**: First-class support for arrays of any supported type using native
    LLVM array types

--- a/specification/Memory_Management.md
+++ b/specification/Memory_Management.md
@@ -35,6 +35,15 @@ To use dynamic allocation, set the following module flags to `true`:
 When these flags are set, the `required_num_qubits` and `required_num_results`
 attributes on the entry point are not required; the runtime manages allocation.
 
+### Enabling Array Support
+
+To use arrays of qubits and results, set the following module flag to `true`:
+
+- `"arrays"`
+
+This flag enables array support for both qubits and results, regardless of
+whether they are allocated statically or dynamically.
+
 ### Types
 
 Use native LLVM array types (`[%N x ptr]`) and `alloca` for stack
@@ -45,19 +54,19 @@ allocation, or heap allocation as needed.
 **Qubit management:**
 
 ```llvm
-declare ptr @__quantum__rt__qubit_allocate()
+declare ptr @__quantum__rt__qubit_allocate(ptr %out_err)
 declare void @__quantum__rt__qubit_release(ptr %qubit)
 ; Caller provides a buffer capable of holding N pointer-sized entries.
-declare void @__quantum__rt__qubit_array_allocate(i64 %N, ptr %array)
+declare void @__quantum__rt__qubit_array_allocate(i64 %N, ptr %array, ptr %out_err)
 declare void @__quantum__rt__qubit_array_release(i64 %N, ptr %array)
 ```
 
 **Result management:**
 
 ```llvm
-declare ptr @__quantum__rt__result_allocate()
+declare ptr @__quantum__rt__result_allocate(ptr %out_err)
 declare void @__quantum__rt__result_release(ptr %result)
-declare void @__quantum__rt__result_array_allocate(i64 %N, ptr %array)
+declare void @__quantum__rt__result_array_allocate(i64 %N, ptr %array, ptr %out_err)
 declare void @__quantum__rt__result_array_release(i64 %N, ptr %array)
 ```
 
@@ -68,8 +77,17 @@ declare void @__quantum__rt__result_array_release(i64 %N, ptr %array)
   memory.
 - The `array_release` functions release the runtime-managed objects, but do not
   free the classical buffer.
-- A separate fallible allocation API such as `__quantum__rt__try_qubit_allocate`
-  (returning `null` on failure) is under discussion.
+
+**Error handling:**
+
+- All allocation functions accept an optional output parameter `%out_err` for
+  error handling.
+- If `%out_err` is `null`, allocation failure results in runtime termination
+  (crash). This is the common case for most programs.
+- If `%out_err` is non-null, the caller must have allocated memory for an `i1`
+  and passed a pointer to it. The runtime will set this `i1` to `true` on
+  allocation failure and `false` on success. Advanced users can check this flag
+  to handle allocation failures gracefully.
 
 ### Array Output Recording
 
@@ -80,6 +98,10 @@ declare void @__quantum__rt__result_array_record_output(i64 %N, ptr %result_arra
 ```
 
 `%N` is the size of `%result_array`. Endianness for rendering is undecided.
+
+**Note:** This is the only specialized array output recording function. No
+additional output recording functions will be introduced for other types or
+purposes.
 
 ### Support Matrix
 
@@ -92,15 +114,24 @@ When describing container/object capabilities, consider two axes:
 This yields four supported scenarios (stack/heap × dynamic/static) and clarifies
 compiler/runtime responsibilities.
 
+### Qubit State After Release
+
+The state of a qubit after `__quantum__rt__qubit_release` is backend-specific.
+Backends may return qubits in a clean state (e.g., reset to |0⟩) or in a dirty
+state (whatever state the qubit was in when released). Programs should not rely
+on any particular state and should explicitly reset qubits if a known state is
+required.
+
 ### Rationale and Implementation Notes
 
 - Caller-managed classical memory keeps memory semantics simple and leverages
   LLVM's native array and aggregate operations.
 - Separating classical memory lifetime from runtime-managed quantum objects
   simplifies backends.
+- The error handling approach via output parameters allows most programs to use
+  simple allocation with implicit failure handling while enabling advanced users
+  to handle allocation failures explicitly.
 
 ## Open Questions
 
-- Final decision on allocation failure handling (`try_` APIs vs result-style returns)
 - Exact semantics for `result_array_record_output` formatting (endianness)
-- Whether to introduce additional module flags to indicate array support

--- a/specification/Memory_Management.md
+++ b/specification/Memory_Management.md
@@ -1,0 +1,106 @@
+
+# Dynamic Allocation and Arrays
+
+As of v1.0, QIR only supported handling of qubits and results statically known
+at compile time. This extension for QIR 2.0
+[Adaptive Profile](./profiles/Adaptive_Profile.md) adds the ability to
+dynamically allocate qubits, results and their arrays.
+
+## Motivation & Scope
+
+Dynamic qubit/result allocation and first-class array support enable QIR to represent
+algorithms and workflows that require:
+
+- Allocating ancilla qubits or measurement results at runtime (e.g., for quantum
+  error correction, variational algorithms, or parameterized circuits)
+- Passing qubits and arrays as function arguments, supporting modular and
+  scalable quantum programs
+- Iterating over arrays of qubits/results and returning arrays of measurement results
+- Efficient targeting of devices with varying qubit counts and improved
+  interoperability with advanced quantum languages
+
+This extension maintains backward compatibility with existing QIR tooling and
+profiles, and is designed to keep classical memory management simple (favoring
+stack allocation and native LLVM arrays).
+
+## Specification
+
+### Enabling Dynamic Memory Management
+
+To use dynamic allocation, set the following module flags to `true`:
+
+- `"dynamic_qubit_management"`
+- `"dynamic_result_management"`
+
+When these flags are set, the `required_num_qubits` and `required_num_results`
+attributes on the entry point are not required; the runtime manages allocation.
+
+### Types
+
+Use native LLVM array types (`[%N x ptr]`) and `alloca` for stack
+allocation, or heap allocation as needed.
+
+### Runtime API
+
+**Qubit management:**
+
+```llvm
+declare ptr @__quantum__rt__qubit_allocate()
+declare void @__quantum__rt__qubit_release(ptr %qubit)
+; Caller provides a buffer capable of holding N pointer-sized entries.
+declare void @__quantum__rt__qubit_array_allocate(i64 %N, ptr %array)
+declare void @__quantum__rt__qubit_array_release(i64 %N, ptr %array)
+```
+
+**Result management:**
+
+```llvm
+declare ptr @__quantum__rt__result_allocate()
+declare void @__quantum__rt__result_release(ptr %result)
+declare void @__quantum__rt__result_array_allocate(i64 %N, ptr %array)
+declare void @__quantum__rt__result_array_release(i64 %N, ptr %array)
+```
+
+**Notes:**
+
+- The `array_allocate` functions write N pointer values into the memory at
+  `%array`. The caller is responsible for allocating and freeing the classical
+  memory.
+- The `array_release` functions release the runtime-managed objects, but do not
+  free the classical buffer.
+- A separate fallible allocation API such as `__quantum__rt__try_qubit_allocate`
+  (returning `null` on failure) is under discussion.
+
+### Array Output Recording
+
+To record/print an entire measurement result array in one line:
+
+```llvm
+declare void @__quantum__rt__result_array_record_output(i64 %N, ptr %result_array, ptr %tag)
+```
+
+`%N` is the size of `%result_array`. Endianness for rendering is undecided.
+
+### Support Matrix
+
+When describing container/object capabilities, consider two axes:
+
+- Container allocation: Stack (compile-time size) vs Heap (runtime size)
+- Object creation: Dynamic (via `dynamic_*_management` flags) vs Static
+  (compile-time ID via `required_num_*` flags)
+
+This yields four supported scenarios (stack/heap × dynamic/static) and clarifies
+compiler/runtime responsibilities.
+
+### Rationale and Implementation Notes
+
+- Caller-managed classical memory keeps memory semantics simple and leverages
+  LLVM's native array and aggregate operations.
+- Separating classical memory lifetime from runtime-managed quantum objects
+  simplifies backends.
+
+## Open Questions
+
+- Final decision on allocation failure handling (`try_` APIs vs result-style returns)
+- Exact semantics for `result_array_record_output` formatting (endianness)
+- Whether to introduce additional module flags to indicate array support

--- a/specification/Memory_Management.md
+++ b/specification/Memory_Management.md
@@ -262,7 +262,7 @@ for arrays.
 
 ### Dynamic Allocation Examples
 
-**Single qubit allocation:**
+#### Single qubit allocation
 
 ```llvm
 %qubit = call ptr @__quantum__rt__qubit_allocate(ptr null)
@@ -270,7 +270,7 @@ call void @__quantum__qis__h__body(ptr %qubit)
 call void @__quantum__rt__qubit_release(ptr %qubit)
 ```
 
-**Single qubit allocation with error checking:**
+#### Single qubit allocation with error checking
 
 This example shows how to handle allocation failures gracefully. By passing a
 non-null pointer to an `i1` as the `%out_err` parameter, the caller can check
@@ -294,7 +294,12 @@ continue:
   ret void
 ```
 
-**Bulk qubit allocation (requires arrays):**
+#### Array-Based Allocation
+
+The following examples require both dynamic allocation and array support to be
+enabled.
+
+##### Bulk qubit allocation
 
 ```llvm
 %qubits = alloca [5 x ptr], align 8
@@ -307,7 +312,7 @@ call void @__quantum__qis__h__body(ptr %q0)
 call void @__quantum__rt__qubit_array_release(i64 5, ptr %qubits)
 ```
 
-**Result array allocation and output (requires arrays):**
+##### Result array allocation and output
 
 ```llvm
 %results = alloca [3 x ptr], align 8
@@ -320,6 +325,37 @@ call void @__quantum__qis__mz__body(ptr %qubit0, ptr %r0)
 call void @__quantum__rt__result_array_record_output(i64 3, ptr %results, ptr @tag)
 ; Release when done
 call void @__quantum__rt__result_array_release(i64 3, ptr %results)
+```
+
+##### Bulk measurement
+
+This example demonstrates a hypothetical bulk measurement QIS instruction that
+backends may choose to support for efficiency. The instruction takes an array of
+qubits and an array of results, performing all measurements in a single call.
+
+```llvm
+; Allocate qubits and results
+%qubits = alloca [5 x ptr], align 8
+%results = alloca [5 x ptr], align 8
+call void @__quantum__rt__qubit_array_allocate(i64 5, ptr %qubits, ptr null)
+call void @__quantum__rt__result_array_allocate(i64 5, ptr %results, ptr null)
+
+; Prepare qubits
+%q0_ptr = getelementptr inbounds [5 x ptr], ptr %qubits, i64 0, i64 0
+%q0 = load ptr, ptr %q0_ptr, align 8
+call void @__quantum__qis__h__body(ptr %q0)
+; ... prepare other qubits
+
+; Perform bulk measurement using a hypothetical QIS instruction
+; Backends that support this instruction can optimize the measurement operation
+call void @__quantum__qis__mz_array__body(i64 5, ptr %qubits, ptr %results)
+
+; Record the entire result array as output
+call void @__quantum__rt__result_array_record_output(i64 5, ptr %results, ptr @tag)
+
+; Release resources
+call void @__quantum__rt__qubit_array_release(i64 5, ptr %qubits)
+call void @__quantum__rt__result_array_release(i64 5, ptr %results)
 ```
 
 ## Combined Capabilities Matrix

--- a/specification/output_schemas/Grammars.md
+++ b/specification/output_schemas/Grammars.md
@@ -39,7 +39,7 @@ container = (tuple / array)
 ### Labeled
 
 ```abnf
-value = output-start (result / bool / int / double) TAB label
+value = output-start (result / result-array / bool / int / double) TAB label
 
 tuple = output-start TUPLE-LIT TAB 1*DIGIT TAB label
 
@@ -49,7 +49,7 @@ array = output-start ARRAY-LIT TAB 1*DIGIT TAB label
 ### No Labels and Ordered
 
 ```abnf
-value = output-start (result / bool / int / double)
+value = output-start (result / result-array / bool / int / double)
 
 tuple = output-start tuple-start 1*collection-items
 
@@ -74,6 +74,8 @@ tuple-items = 1*(EOL tuple)
 output-start = OUTPUT-LIT TAB
 
 result = RESULT-LIT TAB BIT
+
+result-array = RESULT-ARRAY-LIT TAB 1*BIT
 
 bool = BOOL-LIT TAB (TRUE-LIT / FALSE-LIT)
 
@@ -159,6 +161,8 @@ INT-LIT = "I" "N" "T"
 DOUBLE-LIT = "D" "O" "U" "B" "L" "E"
 
 RESULT-LIT = "R" "E" "S" "U" "L" "T"
+
+RESULT-ARRAY-LIT = "R" "E" "S" "U" "L" "T" "_" "A" "R" "R" "A" "Y"
 
 END-LIT = "E" "N" "D"
 ```

--- a/specification/output_schemas/Labeled.md
+++ b/specification/output_schemas/Labeled.md
@@ -67,6 +67,30 @@ Produces output records of the format `"OUTPUT\tRESULT\t0\tlabel"` or
 element is a string label associated to the result value which is included in
 the corresponding output record.
 
+### Result Array
+
+```llvm
+void @__quantum__rt__result_array_record_output(i64, ptr, ptr)
+```
+
+This function is available when the `arrays` module flag is set to `true` (see
+[Adaptive Profile](../profiles/Adaptive_Profile.md#bullet-11-arrays)).
+
+Produces a single output record of the format `"OUTPUT\tRESULT_ARRAY\tb\tlabel"`
+where `b` is a binary string representation of the result array and `label` is
+the string label associated to the array. The array is output in memory order:
+the first element in the array (at index 0, the lowest memory address) appears
+as the first (leftmost) bit in the output string, followed by subsequent array
+elements.
+
+For example, if the result array contains three results `[1, 0, 1]` (in memory
+order) and the label is `"results"`, the output would be
+`"OUTPUT\tRESULT_ARRAY\t101\tresults"`.
+
+**Note:** This is the only specialized array output recording function for the
+labeled schema. Arrays of other types (if supported in future profiles) should
+use the generic array container format.
+
 ### Boolean
 
 ```llvm

--- a/specification/output_schemas/Labeled.md
+++ b/specification/output_schemas/Labeled.md
@@ -3,6 +3,8 @@
 This output schema is meant for backends that asynchronously emit output records
 and support strings as arguments to functions.
 
+**Schema Version**: 2.1 (added `RESULT_ARRAY` type for array output support)
+
 The labeled output schema for asynchronous output emission is the same as the
 [ordered schema](./Ordered.md) with the following changes:
 
@@ -27,7 +29,7 @@ Here's an example of the output emitted for a single shot:
 
 ```log
 HEADER\tschema_id\tlabeled
-HEADER\tschema_version\t2.0
+HEADER\tschema_version\t2.1
 START
 METADATA\tentry_point
 METADATA\tqir_profiles\tbase_profile
@@ -167,7 +169,7 @@ The output for `3` shots would have the following form (using fabricated
 
 ```log
 HEADER\tschema_id\tlabeled
-HEADER\tschema_version\t2.0
+HEADER\tschema_version\t2.1
 START
 METADATA\tentry_point
 METADATA\tqir_profiles\tbase_profile
@@ -210,7 +212,7 @@ The output for `3` shots would have the following form (using fabricated
 
 ```log
 HEADER\tschema_id\tlabeled
-HEADER\tschema_version\t2.0
+HEADER\tschema_version\t2.1
 START
 METADATA\tentry_point
 METADATA\tqir_profiles\tbase_profile
@@ -260,7 +262,7 @@ The output for `3` shots would have the following form (using fabricated
 
 ```log
 HEADER\tschema_id\tlabeled
-HEADER\tschema_version\t2.0
+HEADER\tschema_version\t2.1
 START
 METADATA\tentry_point
 METADATA\tqir_profiles\tbase_profile
@@ -312,7 +314,7 @@ The output for one shot would have the following form (using fabricated
 
 ```log
 HEADER\tschema_id\tlabeled
-HEADER\tschema_version\t2.0
+HEADER\tschema_version\t2.1
 START
 METADATA\tentry_point
 METADATA\tqir_profiles\tbase_profile

--- a/specification/output_schemas/Notes.md
+++ b/specification/output_schemas/Notes.md
@@ -156,7 +156,7 @@ Output for a single shot:
 
 ```log
 HEADER\tschema_id\tlabeled
-HEADER\tschema_version\t2.0
+HEADER\tschema_version\t2.1
 START
 METADATA\tentry_point
 METADATA\trequired_num_qubits\t5

--- a/specification/output_schemas/Ordered.md
+++ b/specification/output_schemas/Ordered.md
@@ -107,12 +107,14 @@ additional elements:
 - _data_type_: A string that specifies the data type, which can be classified as
 a primitive data type or a container data type:
   - Primitive data types: Represent particular kinds of data and can be any of
-the following: `RESULT`, `BOOL`, `INT` or `DOUBLE`.
+the following: `RESULT`, `BOOL`, `INT`, `DOUBLE`, or `RESULT_ARRAY` (available
+when arrays are enabled).
   - Container types: Represent kinds of containers and can be any of the
 following: `TUPLE` or `ARRAY`.
 - _data_value_: A string that represent the value of the output for primitive
 data types or an integer that represents the number of elements for container
-types.
+types. For `RESULT_ARRAY`, this is a binary string in memory order (first array
+element appears first in the string).
 
 `OUTPUT` records are emitted based on the
 [output recording function](../profiles/Base_Profile.md#output-recording) calls
@@ -128,6 +130,7 @@ OUTPUT\tBOOL\ttrue
 OUTPUT\tBOOL\tfalse
 OUTPUT\tINT\t42
 OUTPUT\tDOUBLE\t3.14159
+OUTPUT\tRESULT_ARRAY\t1010
 OUTPUT\tARRAY\t4
 OUTPUT\tRESULT\t0
 OUTPUT\tRESULT\t0
@@ -198,6 +201,28 @@ void @__quantum__rt__result_record_output(ptr, ptr)
 
 Produces output records that are exactly `"OUTPUT\tRESULT\t0"` or
 `"OUTPUT\tRESULT\t1"`, representing measurement results.
+
+### Result Array
+
+```llvm
+void @__quantum__rt__result_array_record_output(i64, ptr, ptr)
+```
+
+This function is available when the `arrays` module flag is set to `true` (see
+[Adaptive Profile](../profiles/Adaptive_Profile.md#bullet-11-arrays)).
+
+Produces a single output record of the format `"OUTPUT\tRESULT_ARRAY\tb"` where
+`b` is a binary string representation of the result array. The array is output
+in memory order: the first element in the array (at index 0, the lowest memory
+address) appears as the first (leftmost) bit in the output string, followed by
+subsequent array elements.
+
+For example, if the result array contains three results `[1, 0, 1]` (in memory
+order), the output would be `"OUTPUT\tRESULT_ARRAY\t101"`.
+
+**Note:** This is the only specialized array output recording function for the
+ordered schema. Arrays of other types (if supported in future profiles) should
+use the generic array container format described below.
 
 ### Boolean
 
@@ -425,3 +450,43 @@ OUTPUT\tINT\t33
 OUTPUT\tRESULT\t1
 END\t0
 ```
+
+### Result Array Output (with Arrays Enabled)
+
+When the `arrays` module flag is enabled, a QIR program can record an entire
+result array in a single output record using
+`__quantum__rt__result_array_record_output`. For example, with dynamic
+allocation:
+
+```llvm
+@0 = internal constant [11 x i8] c"results_be\00"
+%results = alloca [4 x ptr], align 8
+call void @__quantum__rt__result_array_allocate(i64 4, ptr %results, ptr null)
+; ... perform measurements into the result array ...
+call void @__quantum__rt__result_array_record_output(i64 4, ptr %results, ptr @0)
+call void @__quantum__rt__result_array_release(i64 4, ptr %results)
+ret void
+```
+
+The output for `2` shots where the results are `[1, 0, 1, 1]` and `[0, 1, 0, 0]`
+would have the following form:
+
+```log
+HEADER\tschema_id\tordered
+HEADER\tschema_version\t2.0
+START
+METADATA\tentry_point
+METADATA\tqir_profiles\tadaptive_profile
+METADATA\tdynamic_result_management\ttrue
+METADATA\tarrays\ttrue
+METADATA\toutput_labeling_schema\tordered
+OUTPUT\tRESULT_ARRAY\t1011
+END\t0
+START
+OUTPUT\tRESULT_ARRAY\t0100
+END\t0
+```
+
+Note that the binary string `1011` represents the array in memory order: the
+first element `results[0] = 1` appears as the first (leftmost) bit in the
+output.

--- a/specification/output_schemas/Ordered.md
+++ b/specification/output_schemas/Ordered.md
@@ -3,6 +3,8 @@
 This output schema is meant for backends that can synchronously emit output
 records and do not support strings as arguments to functions.
 
+**Schema Version**: 2.1 (added `RESULT_ARRAY` type for array output support)
+
 ## Records
 
 The output emitted by a system consists of a series of records, where each
@@ -31,7 +33,7 @@ Examples of `HEADER` records:
 
 ```log
 HEADER\tschema_id\tordered
-HEADER\tschema_version\t2.0
+HEADER\tschema_version\t2.1
 ```
 
 ### `START` Records
@@ -147,7 +149,7 @@ The output must start with two `HEADER` records that contain the name and
 version of the output schema used:
 
 - `HEADER\tschema_id\tordered`
-- `HEADER\tschema_version\t2.0`
+- `HEADER\tschema_version\t2.1`
 
 Additional `HEADER` records that provide more general information about the
 output are optional.
@@ -164,7 +166,7 @@ Example of the output emitted for three shots:
 
 ```log
 HEADER\tschema_id\tordered
-HEADER\tschema_version\t2.0
+HEADER\tschema_version\t2.1
 START
 METADATA\tentry_point
 METADATA\tqir_profiles\tbase_profile
@@ -289,7 +291,7 @@ The output for `3` shots would have the following form (using fabricated
 
 ```log
 HEADER\tschema_id\tordered
-HEADER\tschema_version\t2.0
+HEADER\tschema_version\t2.1
 START
 METADATA\tentry_point
 METADATA\tqir_profiles\tbase_profile
@@ -332,7 +334,7 @@ The output for `3` shots would have the following form (using fabricated
 
 ```log
 HEADER\tschema_id\tordered
-HEADER\tschema_version\t2.0
+HEADER\tschema_version\t2.1
 START
 METADATA\tentry_point
 METADATA\tqir_profiles\tbase_profile
@@ -382,7 +384,7 @@ The output for `3` shots would have the following form (using fabricated
 
 ```log
 HEADER\tschema_id\tordered
-HEADER\tschema_version\t2.0
+HEADER\tschema_version\t2.1
 START
 METADATA\tentry_point
 METADATA\tqir_profiles\tbase_profile
@@ -434,7 +436,7 @@ The output for one shot would have the following form (using fabricated
 
 ```log
 HEADER\tschema_id\tordered
-HEADER\tschema_version\t2.0
+HEADER\tschema_version\t2.1
 START
 METADATA\tentry_point
 METADATA\tqir_profiles\tbase_profile
@@ -473,7 +475,7 @@ would have the following form:
 
 ```log
 HEADER\tschema_id\tordered
-HEADER\tschema_version\t2.0
+HEADER\tschema_version\t2.1
 START
 METADATA\tentry_point
 METADATA\tqir_profiles\tadaptive_profile

--- a/specification/output_schemas/qir-output.py
+++ b/specification/output_schemas/qir-output.py
@@ -31,9 +31,12 @@ def main():
         container: tuple | array
 
         // Labeled
-        value: OUTPUT_LIT TAB (RESULT_LIT TAB BIT | BOOL_LIT TAB (TRUE_LIT | FALSE_LIT) | INT_LIT TAB SIGNED_DIGIT | DOUBLE_LIT TAB DOUBLE_VALUE) (TAB label)?
+        value: OUTPUT_LIT TAB (result | result_array | BOOL_LIT TAB (TRUE_LIT | FALSE_LIT) | INT_LIT TAB SIGNED_DIGIT | DOUBLE_LIT TAB DOUBLE_VALUE) (TAB label)?
         tuple: OUTPUT_LIT TAB TUPLE_LIT TAB DIGITS (TAB label)?
         array: OUTPUT_LIT TAB ARRAY_LIT TAB DIGITS (TAB label)?
+
+        result: RESULT_LIT TAB BIT
+        result_array: RESULT_ARRAY_LIT TAB BITS
 
         // Ordered
         // (Extend as needed for ordered/collection-items)
@@ -60,6 +63,7 @@ def main():
         INT_LIT: "INT"
         DOUBLE_LIT: "DOUBLE"
         RESULT_LIT: "RESULT"
+        RESULT_ARRAY_LIT: "RESULT_ARRAY"
         TUPLE_LIT: "TUPLE"
         ARRAY_LIT: "ARRAY"
         TRUE_LIT: "true"
@@ -68,6 +72,7 @@ def main():
         INFINITY_LIT: "INFINITY"
         NAN_LIT: "NAN"
         BIT: "0" | "1"
+        BITS: BIT+
         SIGN: "+" | "-"
         DIGIT: /[0-9]/
         DIGITS: DIGIT+

--- a/specification/profiles/Adaptive_Profile.md
+++ b/specification/profiles/Adaptive_Profile.md
@@ -703,7 +703,7 @@ the quantum instruction set, we refer to the paragraph on [Bullet
 
 ## Classical Instructions
 
-The following table lists all classical instructions the must be supported to
+The following table lists all classical instructions that must be supported to
 execute a minimal Adaptive Profile program, that is a program that does not make
 use of any optional capabilities:
 

--- a/specification/profiles/Adaptive_Profile.md
+++ b/specification/profiles/Adaptive_Profile.md
@@ -48,13 +48,15 @@ support more advanced adaptive computations:
 7. Support for control flow loops (backwards branching).
 8. Multiple target branching.
 9. Multiple return points.
-10. Dynamic allocation of qubits and results, and support for arrays of these
-    resources (see [Dynamic Allocation and Arrays](../Memory_Management.md)).
+10. Dynamic allocation of qubits and results at runtime (see [Dynamic
+    Allocation and Arrays](../Memory_Management.md)).
+11. Support for arrays of qubits and results (see [Dynamic Allocation and
+    Arrays](../Memory_Management.md)).
 <!-- markdownlint-enable MD029 -->
 
 The use of these optional features is represented as a [module
 flag](#module-flags-metadata) in the program IR. Any backend that supports
-capabilities 1-4, and as many of capabilities 5-10 as it desires, is considered
+capabilities 1-4, and as many of capabilities 5-11 as it desires, is considered
 as supporting Adaptive Profile programs. Static analysis/verification tools
 should be able to determine what capabilities of the Adaptive Profile a backend
 is implementing and should run a verification pass to ensure Adaptive Profile
@@ -354,21 +356,86 @@ propagating the computed output to a single final block. Any use of this
 optional capability must be indicated in the form of [module
 flags](#module-flags-metadata) in the program IR.
 
-### Bullet 10: Dynamic Allocation and Arrays
+### Bullet 10: Dynamic Allocation
 
 A backend may choose to support dynamic allocation of qubits and results at
-runtime, as well as arrays of these resources. This capability enables
-algorithms that require allocating resources during execution (e.g., for quantum
-error correction or parameterized circuits). When this capability is enabled,
-the `required_num_qubits` and `required_num_results` attributes on the entry
-point are not required.
+runtime. This capability enables algorithms that require allocating resources
+during execution (e.g., for quantum error correction or parameterized circuits).
 
-This capability is indicated via the module flags `dynamic_qubit_management`
-and/or `dynamic_result_management`. The specific runtime API functions and usage
-patterns are defined in the [Dynamic Allocation and
-Arrays](../Memory_Management.md) specification. This includes support for
-caller-managed classical memory with runtime-managed quantum objects, enabling
-use of native LLVM array types and stack allocation via `alloca`.
+Dynamic allocation is indicated via the module flags `dynamic_qubit_management`
+and/or `dynamic_result_management`. When enabled for a resource type, the
+`required_num_qubits` or `required_num_results` attributes (respectively) on the
+entry point are not required, and resources are allocated using the runtime API
+functions defined in the [Dynamic Allocation and
+Arrays](../Memory_Management.md) specification.
+
+The single-resource allocation functions are:
+
+```llvm
+declare ptr @__quantum__rt__qubit_allocate(ptr %out_err)
+declare void @__quantum__rt__qubit_release(ptr %qubit)
+declare ptr @__quantum__rt__result_allocate(ptr %out_err)
+declare void @__quantum__rt__result_release(ptr %result)
+```
+
+These functions may only be used when the corresponding dynamic management flag
+is enabled. See the [Dynamic Allocation and Arrays](../Memory_Management.md)
+specification for detailed semantics, error handling, and usage examples.
+
+### Bullet 11: Arrays
+
+A backend may choose to support arrays of qubits and results. This capability is
+orthogonal to dynamic allocation (**Bullet 10**): arrays can be used with either
+statically allocated resources (using integer-to-pointer casts as in the base
+Adaptive Profile) or dynamically allocated resources (using runtime allocation
+functions).
+
+Array support is indicated via the module flag `"arrays"`. When enabled, programs
+may use native LLVM array types to represent collections of qubits or results.
+
+When arrays are enabled, the following LLVM features for working with arrays
+must be supported:
+
+- **Array types**: Native LLVM array types such as `[N x ptr]` for fixed-size
+  arrays of N pointers (where pointers represent qubits or results).
+- **Stack allocation**: The `alloca` instruction for allocating arrays on the
+  stack with compile-time known sizes.
+- **Element access**: The `getelementptr` (GEP) instruction for computing
+  addresses of array elements. The indices used in GEP must be either constants
+  or values that do not depend on quantum measurements (unless iterations or
+  conditionally terminating loops are also supported via **Bullet 7**).
+- **Aggregate operations**: The `extractvalue` and `insertvalue` instructions
+  for accessing and modifying elements of aggregate types, when used with
+  constant indices.
+- **Load/Store**: Standard `load` and `store` instructions for reading from and
+  writing to array elements.
+
+Note that LLVM does not natively support dynamically-sized arrays (i.e., arrays
+whose size is determined at runtime). For dynamically-sized collections, the
+classical memory management (e.g., allocating a buffer of the appropriate size)
+remains the responsibility of the caller, as described in the [Dynamic
+Allocation and Arrays](../Memory_Management.md) specification. The runtime API
+functions operate on caller-provided memory buffers, enabling flexible memory
+management strategies.
+
+When arrays are enabled, the following array-specific runtime functions become
+available:
+
+```llvm
+declare void @__quantum__rt__qubit_array_allocate(i64 %N, ptr %array, ptr %out_err)
+declare void @__quantum__rt__qubit_array_release(i64 %N, ptr %array)
+declare void @__quantum__rt__result_array_allocate(i64 %N, ptr %array, ptr %out_err)
+declare void @__quantum__rt__result_array_release(i64 %N, ptr %array)
+declare void @__quantum__rt__result_array_record_output(i64 %N, ptr %result_array, ptr %tag)
+```
+
+These array-specific functions may only be used when the `"arrays"` module flag
+is enabled. The array allocation functions (`*_array_allocate`) additionally
+require the corresponding dynamic management flag (`dynamic_qubit_management` or
+`dynamic_result_management`) to be enabled. See the [Dynamic Allocation and
+Arrays](../Memory_Management.md) specification and the [output
+schemas](../output_schemas/) documentation for detailed semantics and usage
+examples.
 
 A return statement is necessarily always the last statement in a block. For each
 block that returns a zero exit code in the entry point function, that
@@ -817,8 +884,9 @@ and results via the runtime API functions defined in the [Dynamic Allocation and
 Arrays](../Memory_Management.md) specification. In this case, the
 `required_num_qubits` and `required_num_results` attributes are not required,
 and qubits/results are identified by pointer values returned from allocation
-functions rather than integer casts. The specific usage patterns and constraints
-are detailed in the dynamic allocation specification.
+functions rather than integer casts. If **Bullet 11** (arrays) is also enabled,
+array allocation functions may be used. The specific usage patterns and
+constraints are detailed in the dynamic allocation specification.
 
 ## Attributes
 
@@ -873,13 +941,29 @@ indicates that these capabilities are not used in the program.
   a function within the IR as defined [here](#bullet-9-multiple-return-points).
 - A flag named `"dynamic_qubit_management"` with a constant `true` or `false`
   value of type `i1` indicating whether the program uses [dynamic qubit
-  allocation and release](#bullet-10-dynamic-allocation-and-arrays).
+  allocation and release](#bullet-10-dynamic-allocation). When set to `true`,
+  the runtime API functions `__quantum__rt__qubit_allocate` and
+  `__quantum__rt__qubit_release` may be used in the program. If
+  [arrays](#bullet-11-arrays) are also enabled, `__quantum__rt__qubit_array_allocate`
+  and `__quantum__rt__qubit_array_release` may also be used.
 - A flag named `"dynamic_result_management"` with a constant `true` or `false`
   value of type `i1` indicating whether the program uses [dynamic result
-  allocation and release](#bullet-10-dynamic-allocation-and-arrays).
+  allocation and release](#bullet-10-dynamic-allocation). When set to `true`,
+  the runtime API functions `__quantum__rt__result_allocate` and
+  `__quantum__rt__result_release` may be used in the program. If
+  [arrays](#bullet-11-arrays) are also enabled, `__quantum__rt__result_array_allocate`
+  and `__quantum__rt__result_array_release` may also be used.
 - A flag named `"arrays"` with a constant `true` or `false` value of type `i1`
-  indicating whether the program uses arrays of qubits or results as defined in
-  [Dynamic Allocation and Arrays](#bullet-10-dynamic-allocation-and-arrays).
+  indicating whether the program uses [arrays](#bullet-11-arrays) of qubits or
+  results. When set to `true`, programs may use native LLVM array types, the
+  `alloca` instruction for stack-allocated arrays, and array-related aggregate
+  operations as described in **Bullet 11**. Additionally, the
+  `__quantum__rt__result_array_record_output` function may be used for recording
+  result arrays. The array allocation/release functions
+  (`__quantum__rt__qubit_array_allocate`, `__quantum__rt__qubit_array_release`,
+  `__quantum__rt__result_array_allocate`, `__quantum__rt__result_array_release`)
+  require both this flag and the corresponding dynamic management flag to be
+  enabled. When set to `false`, these features must not be used.
 
 ## Error Messages
 

--- a/specification/profiles/Adaptive_Profile.md
+++ b/specification/profiles/Adaptive_Profile.md
@@ -48,11 +48,13 @@ support more advanced adaptive computations:
 7. Support for control flow loops (backwards branching).
 8. Multiple target branching.
 9. Multiple return points.
+10. Dynamic allocation of qubits and results, and support for arrays of these
+    resources (see [Dynamic Allocation and Arrays](../Memory_Management.md)).
 <!-- markdownlint-enable MD029 -->
 
 The use of these optional features is represented as a [module
 flag](#module-flags-metadata) in the program IR. Any backend that supports
-capabilities 1-4, and as many of capabilities 5-9 as it desires, is considered
+capabilities 1-4, and as many of capabilities 5-10 as it desires, is considered
 as supporting Adaptive Profile programs. Static analysis/verification tools
 should be able to determine what capabilities of the Adaptive Profile a backend
 is implementing and should run a verification pass to ensure Adaptive Profile
@@ -351,6 +353,22 @@ supported. This eliminates the need to create `phi` nodes for the purpose of
 propagating the computed output to a single final block. Any use of this
 optional capability must be indicated in the form of [module
 flags](#module-flags-metadata) in the program IR.
+
+### Bullet 10: Dynamic Allocation and Arrays
+
+A backend may choose to support dynamic allocation of qubits and results at
+runtime, as well as arrays of these resources. This capability enables
+algorithms that require allocating resources during execution (e.g., for quantum
+error correction or parameterized circuits). When this capability is enabled,
+the `required_num_qubits` and `required_num_results` attributes on the entry
+point are not required.
+
+This capability is indicated via the module flags `dynamic_qubit_management`
+and/or `dynamic_result_management`. The specific runtime API functions and usage
+patterns are defined in the [Dynamic Allocation and
+Arrays](../Memory_Management.md) specification. This includes support for
+caller-managed classical memory with runtime-managed quantum objects, enabling
+use of native LLVM array types and stack allocation via `alloca`.
 
 A return statement is necessarily always the last statement in a block. For each
 block that returns a zero exit code in the entry point function, that
@@ -773,24 +791,34 @@ details.
 
 The `ptr` type must be supported by all backends.
 Qubits and results can occur only as arguments in function calls and are
-represented as an opaque pointer. To be
-compliant with the Adaptive Profile specification, the program must not make use
-of dynamic qubit or result management, meaning qubits and results must be
-identified by an integer value that is bitcast to a pointer to match the
-expected type. How such an integer value is interpreted and specifically how it
-relates to hardware resources is ultimately up to the executing backend.
+represented as an opaque pointer.
+
+**Without dynamic allocation (default):** Unless the optional capability in
+**Bullet 10** is enabled, qubits and results must be identified by an integer
+value that is bitcast to a pointer to match the expected type. How such an
+integer value is interpreted and specifically how it relates to hardware
+resources is ultimately up to the executing backend.
 
 The integer value that is cast must be either a constant, or a phi node of
 integer type if [iterations](#bullet-7-backwards-branching) are used/supported.
 If the cast value is a phi node, it must not directly or indirectly depend on
 any quantum measurements. The integer constant that is cast must be in the
-interval `[0, numQubits)` for qubits and `[0,numResults)` for results,
+interval `[0, numQubits)` for qubits and `[0, numResults)` for results,
 where `numQubits` and `numResults` are the required number of qubits and results
 defined by the corresponding [entry point attributes](#attributes). Since
 backends may look at the values of the `required_num_qubits` and
 `required_num_results` attributes to determine whether a program can be
 executed, it is recommended to index qubits and results consecutively so that
 there are no unused values within these ranges.
+
+**With dynamic allocation enabled:** If the backend supports the optional
+capability in **Bullet 10**, the program may use dynamic allocation of qubits
+and results via the runtime API functions defined in the [Dynamic Allocation and
+Arrays](../Memory_Management.md) specification. In this case, the
+`required_num_qubits` and `required_num_results` attributes are not required,
+and qubits/results are identified by pointer values returned from allocation
+functions rather than integer casts. The specific usage patterns and constraints
+are detailed in the dynamic allocation specification.
 
 ## Attributes
 
@@ -843,6 +871,12 @@ indicates that these capabilities are not used in the program.
 - A flag named `"multiple_return_points"`  with a constant `true` or `false`
   value of type `i1` indicating whether multiple return statements can apper in
   a function within the IR as defined [here](#bullet-9-multiple-return-points).
+- A flag named `"dynamic_qubit_management"` with a constant `true` or `false`
+  value of type `i1` indicating whether the program uses [dynamic qubit
+  allocation and release](#bullet-10-dynamic-allocation-and-arrays).
+- A flag named `"dynamic_result_management"` with a constant `true` or `false`
+  value of type `i1` indicating whether the program uses [dynamic result
+  allocation and release](#bullet-10-dynamic-allocation-and-arrays).
 
 ## Error Messages
 

--- a/specification/profiles/Adaptive_Profile.md
+++ b/specification/profiles/Adaptive_Profile.md
@@ -877,6 +877,9 @@ indicates that these capabilities are not used in the program.
 - A flag named `"dynamic_result_management"` with a constant `true` or `false`
   value of type `i1` indicating whether the program uses [dynamic result
   allocation and release](#bullet-10-dynamic-allocation-and-arrays).
+- A flag named `"arrays"` with a constant `true` or `false` value of type `i1`
+  indicating whether the program uses arrays of qubits or results as defined in
+  [Dynamic Allocation and Arrays](#bullet-10-dynamic-allocation-and-arrays).
 
 ## Error Messages
 


### PR DESCRIPTION
Closes: #58 

See render at https://github.com/qartik/qir-spec/blob/58-dyn-alloc-arrays/specification/Memory_Management.md

Open questions
- [x] is there a need for an array measurement function?
	- **Decision**: not in this spec, but it is a QIS intrinsic, we can [show it as an example](https://github.com/qartik/qir-spec/blob/58-dyn-alloc-arrays/specification/Memory_Management.md#bulk-measurement) for any backend that may want to support it
- [x] How do we allow stack memory patterns using `alloca`, `load`, `store` outside of arrays? More [context](https://github.com/qir-alliance/qir-spec/pull/60#discussion_r2829657734).
	- **Decision**: Keep the spec as is, a [future extension may allow these instructions](https://github.com/qir-alliance/qir-spec/pull/60#discussion_r2920250227), if needed.
- [x] Qubit release behavior seems contradictory with allocation, see https://github.com/qir-alliance/qir-spec/pull/60#discussion_r2854786802
	- **Decision**: revised the wording around release to explicitly state that reallocation of a qubit requires a clean state.