### PR TITLE
fix(ci): restore working cla assistant workflow

### DIFF
--- a/.github/workflows/cla_assistant.yml
+++ b/.github/workflows/cla_assistant.yml
@@ -4,13 +4,7 @@ on:
   pull_request_target:
     types: [opened,closed,synchronize]
 
-name: "CLA Assistant"
-
-permissions:
-  actions: write
-  contents: write
-  pull-requests: write
-  statuses: write
+name: "CLA bot"
   
 jobs:
   cla-acknowledgement:
@@ -19,10 +13,10 @@ jobs:
     steps:
       - name: "CLA Assistant"
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the Contributor License Agreement and I hereby accept the Terms.') || github.event_name == 'pull_request_target'
-        uses: contributor-assistant/github-action@v2.3.2
+        uses: cla-assistant/github-action@v2.1.3-beta
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_BOT_ACCESS_TOKEN }}
+          PERSONAL_ACCESS_TOKEN : ${{ secrets.CLA_BOT_ACCESS_TOKEN }}
         with:
           remote-organization-name: qir-alliance
           remote-repository-name: data_storage


### PR DESCRIPTION
## Summary
- switch the CLA workflow back to the org-standard `cla-assistant/github-action@v2.1.3-beta`
- remove the extra workflow permissions block
- keep the `qir-spec` CLA document URL unchanged

## Context
- addresses the CLA failure on PR #60
- mirrors the working CLA workflow pattern used in `qir-alliance/.github`

## Maintainer note
- the CLA check on this PR is still expected to fail because `pull_request_target` runs the workflow from the base branch on `main`
- after this merges, new PRs should run `Check that the CLA has been acknowledged` from `main` with the restored CLA assistant configuration