### PR TITLE
Fix CI issues

### DIFF
--- a/.github/mlc_config.json
+++ b/.github/mlc_config.json
@@ -1,0 +1,8 @@
+{
+  "aliveStatusCodes": [200, 206, 301],
+  "ignorePatterns": [
+    {
+      "pattern": "^https://(www\\.|hub\\.)?packtpub\\.com"
+    }
+  ]
+}

--- a/.github/workflows/link_and_spell_check.yml
+++ b/.github/workflows/link_and_spell_check.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     name: "Check spelling, linting and links"
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - run: |
         wget https://github.com/qir-alliance/.github/archive/refs/heads/main.zip -O clone.zip &&
         unzip clone.zip && mv .github-main out && rm clone.zip &&
@@ -33,6 +33,7 @@ jobs:
       uses: gaurav-nelson/github-action-markdown-link-check@1.0.15
       with:
         use-verbose-mode: 'yes'
+        config-file: '.github/mlc_config.json'
       if: ${{ success() || failure() }}
     - name: "Check spelling in changed files"
       uses: streetsidesoftware/cspell-action@v6


### PR DESCRIPTION
1. Packt is using CloudFlare to block bot requests, resulting in a 403 when our GH Action checks the link.  Accept HTTP 301 as an indicator that the page is still live.
2. Update the checkout action to a version using a supported version of NodeJS.